### PR TITLE
slack api 로 message 긁어와서 bigquery 에 넣는 코드 정리

### DIFF
--- a/exercise.py
+++ b/exercise.py
@@ -1,5 +1,6 @@
-import pandas as pd
+from datetime import datetime
 
+import pandas as pd
 from slacker import Slacker
 
 
@@ -51,4 +52,5 @@ for channel_id in channel_ids:
             messages.append(dict_to_message(channel_id, message))
 
 df = pd.DataFrame(messages)
-df.to_gbq(destination_table='geultto_4th_staging.message_raw', project_id='geultto', if_exists='replace')
+suffix = datetime.now().strftime('%Y%m%d_%H%M%S')  # e.g. 20200315_224904
+df.to_gbq(destination_table=f'geultto_4th_staging.message_raw_{suffix}', project_id='geultto', if_exists='replace')

--- a/exercise.py
+++ b/exercise.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import pandas as pd
 from slacker import Slacker
+import os
 
 
 def dict_to_message(channel_id, d):
@@ -17,7 +18,7 @@ def dict_to_message(channel_id, d):
     }
 
 
-token = '<token>'
+token = os.environ['GEULTTO_SLACK_TOKEN']
 channel_ids = [
     'CTPJHL1H8',  # 3_데분데사a
     'CTPJHM0GJ',  # 3_데분데사b

--- a/exercise.py
+++ b/exercise.py
@@ -12,7 +12,7 @@ def dict_to_message(channel_id, d):
         'parent_user_id': d.get('parent_user_id'),
         'thread_ts': d.get('thread_ts'),
         'text': d['text'],
-        'client_msg_id': d['client_msg_id']
+        'client_msg_id': d.get('client_msg_id')
     }
 
 

--- a/exercise.py
+++ b/exercise.py
@@ -34,15 +34,15 @@ messages = []
 
 for channel_id in channel_ids:
     print(channel_id)
-    body = client.conversations.history(channel=channel_id).body
+    body = client.conversations.history(channel=channel_id, limit=100).body
     assert body['ok'] and not body['has_more'], f'ok: {body["ok"]}, has_more: {body["has_more"]}'
 
     for message in body['messages']:
         # subtype 이 channel_topic, channel_join 인 메시지는 무시하고 None 인 경우 = 보통의 메시지만 취합니다.
         if message.get('type') == 'message' and not message.get('subtype'):
             if message.get('reply_count', 0) > 0:
-                threads = client.conversations.replies(channel=channel_id, ts=message['thread_ts']).body
-                assert threads['ok'] and not threads['has_more']
+                threads = client.conversations.replies(channel=channel_id, ts=message['thread_ts'], limit=100).body
+                assert threads['ok'] and not threads['has_more'], f'{threads["ok"]}, {threads["has_more"]}'
                 for thread in threads['messages']:
                     # threads 에는 thread 뿐 아니라 thread 가 달린 본래 message 까지 있으므로 걸러줍니다.
                     if not message['ts'] == thread['ts']:

--- a/exercise.py
+++ b/exercise.py
@@ -1,0 +1,54 @@
+import pandas as pd
+
+from slacker import Slacker
+
+
+def dict_to_message(channel_id, d):
+    return {
+        'channel_id': channel_id,
+        'ts': d['ts'],
+        'user_id': d['user'],
+        'reactions': [{'name': r['name'], 'user_ids': r['users']} for r in d.get('reactions', [])],
+        'parent_user_id': d.get('parent_user_id'),
+        'thread_ts': d.get('thread_ts'),
+        'text': d['text'],
+        'client_msg_id': d['client_msg_id']
+    }
+
+
+token = '<token>'
+channel_ids = [
+    'CTPJHL1H8',  # 3_데분데사a
+    'CTPJHM0GJ',  # 3_데분데사b
+    'CU2C9MB96',  # 3_데이터엔지니어
+    'CU4882QUF',  # 3_백엔드a_인프라
+    'CTS8D3FFT',  # 3_백엔드b_보안
+    'CU2CW80KF',  # 3_안드로이드
+    'CU2CW93M3',  # 3_프론트a
+    'CTPJJ07UJ'  # 3_프론트b
+]
+
+client = Slacker(token)
+
+messages = []
+
+for channel_id in channel_ids:
+    print(channel_id)
+    body = client.conversations.history(channel=channel_id).body
+    assert body['ok'] and not body['has_more'], f'ok: {body["ok"]}, has_more: {body["has_more"]}'
+
+    for message in body['messages']:
+        # subtype 이 channel_topic, channel_join 인 메시지는 무시하고 None 인 경우 = 보통의 메시지만 취합니다.
+        if message.get('type') == 'message' and not message.get('subtype'):
+            if message.get('reply_count', 0) > 0:
+                threads = client.conversations.replies(channel=channel_id, ts=message['thread_ts']).body
+                assert threads['ok'] and not threads['has_more']
+                for thread in threads['messages']:
+                    # threads 에는 thread 뿐 아니라 thread 가 달린 본래 message 까지 있으므로 걸러줍니다.
+                    if not message['ts'] == thread['ts']:
+                        messages.append(dict_to_message(channel_id, thread))
+
+            messages.append(dict_to_message(channel_id, message))
+
+df = pd.DataFrame(messages)
+df.to_gbq(destination_table='geultto_4th_staging.message_raw', project_id='geultto', if_exists='replace')


### PR DESCRIPTION
코드 정리한 것 + 몇가지 내용을 공유하고 싶은데, Pull Request 가 적절할 것 같아서 만들었습니다.
이 PR 을 merge 하지는 않을 것입니다 ㅋㅋ

# Done

- **slack api 에서 channels 는 deprecated 이므로 conversations 으로 변경**: channels.history 는 thread 로 달린 message 도 내려줘서 편했는데, conversations.history 는 thread 로 달린 message 는 주지 않고, conversations.replies 로 thread 를 따로 받아와야 함.
- **api 결과를 `geultto_4rd_staging` dataset 에 `message_raw` 테이블로 load** : 이후 SQL 로 처리해서 `message` 테이블을 만듦.

# FYI
- channel 안에서 ts 는 unique 하다. 그래서 slack api 들 에서 ts 를 identifer 로 많이 씀.
- channel_id 는 채널 들어가서 아무 메시지나 우클릭 후 copy link 한 다음에 중간에 C 로 시작하는 값 취하면 얻을 수 있음.
- `message_raw.reactions` 컬럼이 python 으로 처리할 때 의미상으로는 dict 의 list 이나, BigQuery 에는 string 타입으로 load 되는데, BigQuery 의 Javascript UDF 로 변환할 수 있을 듯?
```sql
create temp function parse_reactions(str string) returns array<struct<name string, user_ids array<string>>> language js as """
  return JSON.parse(str);
""";

create or replace table geultto_4th_staging.message as
select
  channel_id,
  ts,
  user_id,
  -- JSON.parse 할 때 single quote 면 에러 발생!
  parse_reactions(replace(reactions, '\'', '\"')) as reactions,
  parent_user_id,
  thread_ts,
  text,
  client_msg_id
from 
  geultto_4th_staging.message_raw
```
- 초 단위 + 소수점 아래 6 digits 까지 제공하는 ts 값들은 BigQuery 에는 string 으로 적고, 필요할 때 timestamp 로 변환하는게 좋을 듯.
```sql
select
  ts,
  timestamp_micros(cast(cast(ts as numeric) * 1000000 as int64)),
from 
  geultto_4th_staging.message_raw
```
- submit / pass / feedback 여부를 SQL 로 알아내려면 (`message_raw` -> `message` 를 생성한 뒤에),
```sql
select
  reactions,
  (select count(1) from unnest(reactions) as s where s.name = 'submit') > 0 as is_submit,
  (select count(1) from unnest(reactions) as s where s.name = 'pass') > 0 as is_pass,
  (select count(1) from unnest(reactions) as s where s.name = 'feedback') > 0 as is_feedback,
from
  geultto_4th_staging.message
```
- **feedback 인 경우 어느 메시지에 대한 feedback 인지 알아내려면?** : feedback 메시지의 (channel_id, parent_user_id, thread_ts) 를 (channel_id, user_id, ts) 에 join 하면 됨.
```sql
select
  feedback.channel_id,
  feedback.ts,
  feedback.user_id as user_id_feedback,
  submit.user_id as user_id_submit,
from
  geultto_4th_staging.message as feedback
  left join geultto_4th_staging.message as submit on feedback.channel_id = submit.channel_id
    and feedback.parent_user_id = submit.user_id
    and feedback.thread_ts = submit.ts
where
  (select count(1) from unnest(feedback.reactions) as s where s.name = 'feedback') > 0 -- thread 가 feedback
  and (select count(1) from unnest(submit.reactions) as s where s.name = 'submit') > 0 -- thread 가 달린 message 가 submit
order by
  ts
```