### PR TITLE
submit 테이블 업데이트 추가

### DIFF
--- a/sql/create_submit_tbl.sql
+++ b/sql/create_submit_tbl.sql
@@ -1,0 +1,32 @@
+WITH m AS (
+  SELECT channel_id, FORMAT_TIMESTAMP("%F %T", ts, "Asia/Seoul") ts, user_id, parent_user_id, text,
+    CASE WHEN due_ts = '2020-03-01 15:00:00' THEN 1
+         WHEN due_ts = '2020-03-15 15:00:00' THEN 2 
+         WHEN due_ts = '2020-03-29 15:00:00' THEN 3 
+         WHEN due_ts = '2020-04-12 15:00:00' THEN 4 
+         WHEN due_ts = '2020-04-26 15:00:00' THEN 5 
+         WHEN due_ts = '2020-05-10 15:00:00' THEN 6 
+         WHEN due_ts = '2020-05-24 15:00:00' THEN 7 
+         WHEN due_ts = '2020-06-07 15:00:00' THEN 8 
+         WHEN due_ts = '2020-06-21 15:00:00' THEN 9 
+         WHEN due_ts = '2020-07-05 15:00:00' THEN 10 
+         WHEN due_ts = '2020-07-19 15:00:00' THEN 11 
+         WHEN due_ts = '2020-08-02 15:00:00' THEN 12 
+         WHEN due_ts = '2020-08-16 15:00:00' THEN 13 
+    END round,
+    CASE WHEN parent_user_id IS NULL AND ts < due_ts AND reaction.name = 'submit' THEN 'submit'
+         WHEN parent_user_id IS NULL AND ts < due_ts AND reaction.name = 'pass' THEN 'pass'
+         WHEN parent_user_id IS NOT NULL AND ts < due_ts AND reaction.name = 'feedback' THEN 'feedback'
+    END reaction,
+    CASE WHEN reaction.name = 'submit' THEN CONCAT("https://geultto4.slack.com/archives/", channel_id, "/p", UNIX_MICROS(ts), "/")
+         WHEN reaction.name = 'feedback' THEN CONCAT("https://geultto4.slack.com/archives/", channel_id, "/p", UNIX_MICROS(thread_ts), "/")
+    END m_url,
+    REGEXP_EXTRACT_ALL(REGEXP_REPLACE(IF(reaction.name = 'submit', text, null), "\\|.+>", ">"), "<.+>") post_url
+  FROM `geultto_4th_prod.message` , UNNEST(reactions) reaction
+  WHERE reaction.name IN ('pass', 'feedback', 'submit') AND ts < insert_ts
+)
+
+SELECT u.channel_id, u.user_id, u.channel_name, u.user_name, round, m.ts, m.reaction, m.parent_user_id, m.m_url, m.post_url, m.text
+FROM `geultto_4th_prod.user` u, UNNEST([1,2,3,4,5,6,7,8,9,10,11,12,13]) round
+LEFT JOIN m ON u.user_id = m.user_id AND u.channel_id = m.channel_id AND round = m.round
+;

--- a/update.py
+++ b/update.py
@@ -79,8 +79,14 @@ def update_message(destination):
     job = BIGQUERY_CLIENT.query(sql, job_config=job_config)
     job.result()  # async job 이라 result 를 명시적으로 호출해서 job 이 끝날때까지 blocking 합니다.
 
+def update_submit_table(destination):
+    sql = read_sql('sql/create_submit_tbl.sql')
+    job_config = QueryJobConfig(destination=destination, write_disposition=WriteDisposition.WRITE_TRUNCATE)
+    job = BIGQUERY_CLIENT.query(sql, job_config=job_config)
+    job.result()
 
 if __name__ == '__main__':
     messages = reduce(lambda l1, l2: l1 + l2, [list_channel_messages(channel_id) for channel_id in CHANNEL_IDS])
     insert_to_message_raw(messages)
     update_message('geultto.geultto_4th_prod.message')
+    update_submit_table('geultto.geultto_4th_prod.submit')


### PR DESCRIPTION
@chang12 님이 만드신 코드에 **submit** 테이블 업데이트 하는 코드 추가

- `geultto_4th_prod.message` 테이블에서 submit, pass, feedback 이모지를 단 메시지 파싱
  - 제출 기한 이후의 리액션이 파싱되는 것을 막기 위해 `ts`(제출 시점)가 `insert_ts`(백업 시점), `due_ts`(제출 기한) 보다 이전인 경우만 사용 
- user당 임의로 회차를 생성 + `due_ts`를 이용해 회차 생성 (1~13)
  - 해당 회차에 리액션(pass 등)을 하지 않은 사람 체크
- 슬랙 메시지 url은 제출 글에 대한 url
  - 'submit'일 경우에 해당 메시지 url
  - 'feedback'일 경우에 스레드를 남긴 메시지 url 
- 한 메시지에 여러 글을 제출한 경우, 글 url은 배열로 저장 
  - 사용시 주의; 블로그가 아닌 url이 함께 파싱된 경우 존재 (ex. https://geultto4.slack.com/archives/CU2C9MB96/p1586697889050700/)